### PR TITLE
Updated the DevContainer.json example

### DIFF
--- a/content/codespaces/customizing-your-codespace/configuring-codespaces-for-your-project.md
+++ b/content/codespaces/customizing-your-codespace/configuring-codespaces-for-your-project.md
@@ -56,9 +56,7 @@ Reference your Dockerfile in your `devcontainer.json` file by using the `dockerf
 
 ```json
 {
-  ...
   "build": { "dockerfile": "Dockerfile" },
-  ...
 }
 ```
 


### PR DESCRIPTION
Removed the "..." from the example DevContainer.json example file, as this will cause a build error (to the unknowning end-user).

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [types-of-contributions.md](/main/contributing/types-of-contributions.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

Closes [issue link]

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. If you made changes to the `content` directory, a table will populate in a comment below with the staging and live article links -->

### Check off the following:

- [x] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [x] This pull request impacts the contribution experience
  - [x] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
